### PR TITLE
Improve .gitignore coverage for environments and tools (Issue #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,15 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
-infra/*.tfstate
-infra/.terraform/
+*.tfstate
+.terraform/
+# Environment files
+.env.*
+# Yarn
+yarn.lock
+# macOS
+.AppleDouble
+.LSOverride
+# Docker
+*.pid
+docker-compose.override.yml


### PR DESCRIPTION
This PR improves the .gitignore file to cover additional environments and tools as suggested in Issue #4. It now ignores Terraform state files, environment configs, Yarn, macOS, and Docker artifacts for better cross-platform and multi-tool development.