### PR TITLE
Add pipeline to build and publish Bicep files as artifacts (fixes #8)

### DIFF
--- a/.github/workflows/build-bicep-artifacts.yml
+++ b/.github/workflows/build-bicep-artifacts.yml
@@ -1,0 +1,34 @@
+# Simple GitHub Actions pipeline to build and publish Bicep files as artifacts
+name: Build and Publish Bicep Artifacts
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Bicep CLI
+        uses: Azure/setup-bicep@v2
+
+      - name: Validate Bicep files
+        run: |
+          for file in $(find . -name '*.bicep'); do
+            bicep build "$file"
+          done
+
+      - name: Upload Bicep files as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: bicep-files
+          path: '**/*.bicep'


### PR DESCRIPTION
This PR adds a basic GitHub Actions pipeline that:
- Runs on push and PR to main/dev branches
- Validates all Bicep files in the repo
- Publishes Bicep files as downloadable build artifacts

This addresses Issue #8 and improves automation for infrastructure as code delivery.