### PR TITLE
Fix Bug #12: Remove duplicate 'path' key from workflow file

### DIFF
--- a/.github/workflows/build-bicep-artifacts.yml
+++ b/.github/workflows/build-bicep-artifacts.yml
@@ -37,4 +37,3 @@ jobs:
         with:
           name: bicep-files
           path: '**/*.bicep'
-          path: '**/*.bicep'


### PR DESCRIPTION
This PR fixes Bug #12 by removing the duplicate 'path' key from the upload-artifact step in the workflow file. The workflow should now validate and run successfully.