### PR TITLE
Fix Bug #14: Remove invalid 'prefix' property, use environment() for URLs, and remove unnecessary dependsOn entries

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -49,7 +49,7 @@ resource cdnEndpoint 'Microsoft.Cdn/profiles/endpoints@2023-05-01' = {
       {
         name: 'storageOrigin'
         properties: {
-          hostName: '${storageAccount.name}.blob.core.windows.net'
+                    hostName: '${storageAccount.name}.blob.${environment().suffixes.storage}'
         }
       }
     ]
@@ -90,7 +90,7 @@ resource blobContributorRole 'Microsoft.Authorization/roleAssignments@2020-04-01
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
     principalId: deploymentScriptIdentity.properties.principalId
   }
-  dependsOn: [storageAccount, deploymentScriptIdentity]
+    // dependsOn removed as per linter warning
 }
 
 // Deployment script to upload sample.json

--- a/main-sub.bicep
+++ b/main-sub.bicep
@@ -2,7 +2,5 @@
 module infraModule './infra/main.bicep' = {
   name: 'infraDeployment'
   scope: resourceGroup('CrestAvenue-EU')
-  params: {
-    prefix: 'cdn'
-  }
+params {}
 }


### PR DESCRIPTION
This PR fixes Bug #14 by addressing Bicep validation errors:
- Removes invalid 'prefix' property from main-sub.bicep
- Uses environment() for storage URLs in infra/main.bicep
- Removes unnecessary dependsOn entries as per linter warnings

Pipeline validation should now pass without errors.