### PR TITLE
Feature #16: Remove Bicep validation task from pipeline workflow

### DIFF
--- a/.github/workflows/build-bicep-artifacts.yml
+++ b/.github/workflows/build-bicep-artifacts.yml
@@ -26,15 +26,9 @@ jobs:
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
 
-      - name: Validate Bicep files
-        run: |
-          for file in $(find . -name '*.bicep'); do
-            bicep build "$file"
-          done
 
       - name: Upload Bicep files as artifacts
         uses: actions/upload-artifact@v4
         with:
           name: bicep-files
-          path: '**/*.bicep'
           path: '**/*.bicep'


### PR DESCRIPTION
This PR implements Feature #16 by removing the Bicep validation step from the pipeline workflow (`build-bicep-artifacts.yml`). The workflow now focuses solely on building and uploading Bicep files as artifacts.